### PR TITLE
Support for different positions of special characters when decoding

### DIFF
--- a/base64.lua
+++ b/base64.lua
@@ -109,14 +109,16 @@ function base64.encode( str, encoder, usecaching )
 	return concat( t )
 end
 
-function base64.decode( b64, decoder, usecaching )
+function base64.decode( b64, decoder, usecaching, schar1pos, schar2pos )
 	decoder = decoder or DEFAULT_DECODER
+	schar1pos = schar1pos or 62
+	schar2pos = schar2pos or 63
 	local pattern = '[^%w%+%/%=]'
 	if decoder then
 		local s62, s63
 		for charcode, b64code in pairs( decoder ) do
-			if b64code == 62 then s62 = charcode
-			elseif b64code == 63 then s63 = charcode
+			if b64code == schar1pos then s62 = charcode
+			elseif b64code == schar2pos then s63 = charcode
 			end
 		end
 		pattern = ('[^%%w%%%s%%%s%%=]'):format( char(s62), char(s63) )


### PR DESCRIPTION
The decode function assumes that the special characters in the used Base64 alphabet are always at positions 62 and 63. This is not always true. The alphabet used by [crypt (c)](https://en.wikipedia.org/wiki/Crypt_(C)) has the special characters at positions 0 and 1:

> The radix-64 encoding in crypt is called B64 and uses the alphabet `./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz` which is different than the more common RFC 4648 base64

This PR keeps the changes to a minimum to add support for defining the positions of the special characters when invoking base64.decode(), without breaking backwards compatibility.

Example usage:
``` lua
local base64 = require("base64")

local function crypt_b64_encoder()
  local encoder = {}
  for b64code, char in pairs{[0]=
    '.','/','0','1','2','3','4','5','6','7','8','9','A','B','C','D',
    'E','F','G','H','I','J','K','L','M','N','O','P','Q','R','S','T',
    'U','V','W','X','Y','Z','a','b','c','d','e','f','g','h','i','j',
    'k','l','m','n','o','p','q','r','s','t','u','v','w','x','y','z',
    '='}
  do
    encoder[b64code] = char:byte()
  end
  return encoder
end

local function crypt_b64_decoder()
  local decoder = {}
  for b64code, charcode in pairs(crypt_b64_encoder()) do
    decoder[charcode] = b64code
  end
  return decoder
end

local plain = "tttt"
print(plain) -- output: 'tttt'
local b64 = base64.encode(plain, crypt_b64_encoder())
print(b64) -- output: 'R5FoR.=='
plain = base64.decode(b64, crypt_b64_decoder(), nil, 0, 1)
print(plain) -- output: 'tttt' with this PR, otherwise 'ttt(garbage)'
```